### PR TITLE
Fix .at() on older browsers

### DIFF
--- a/packages/core/src/WebApp/InitData/InitData.ts
+++ b/packages/core/src/WebApp/InitData/InitData.ts
@@ -3,6 +3,26 @@ import { WebAppInitData } from '@typings/WebApp';
 
 import { urlParseQueryString } from '@utils';
 
+function at(n) {
+  // ToInteger() abstract op
+  n = Math.trunc(n) || 0;
+  // Allow negative indexing from the end
+  if (n < 0) n += this.length;
+  // OOB access is guaranteed to return undefined
+  if (n < 0 || n >= this.length) return undefined;
+  // Otherwise, this is just normal property access
+  return this[n];
+}
+
+const TypedArray = Reflect.getPrototypeOf(Int8Array);
+for (const C of [Array, String, TypedArray]) {
+  Object.defineProperty(C.prototype, "at",
+                        { value: at,
+                          writable: true,
+                          enumerable: false,
+                          configurable: true });
+}
+
 type WebAppInitDataValues = ValueOf<WebAppInitData>;
 
 const isWrappedIn = (value: string, open: string, close: string): boolean => {


### PR DESCRIPTION
Added a fallback function for the .at() method, this solves the issue with '.at() is not a function' error on older browsers (i.e. telegram desktop's built-in browser)